### PR TITLE
Run on node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
   head-ref:
     description: 'ref of the head commit to compare (mainly for testing the action)'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   color: blue


### PR DESCRIPTION
I'm getting this warning on my builds starting a couple days ago:
```
[setup-job](https://github.com/Bandwidth/iris/actions/runs/3245261849/jobs/5325182399)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: tony84727/changed-file-filter
```
From my testing in a private repository, it seems to run just fine just changing this one line.